### PR TITLE
Fix cmdline on Linux

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -55,9 +55,9 @@ impl Process {
         f.read_to_end(&mut buffer)?;
 
         let mut ret = Vec::new();
-        for arg in buffer.split(|b| *b == 0) {
+        for arg in buffer.split(|b| *b == 0).filter(|b| b.len() > 0) {
             ret.push(String::from_utf8(arg.to_vec())
-                .map_err(|e| Error::Other(format!("Failed to convert ut8 {}", e)))?)
+                .map_err(|e| Error::Other(format!("Failed to convert utf8 {}", e)))?)
         }
         Ok(ret)
     }


### PR DESCRIPTION
Linux was including an empty commandline argument, because the 'split'
command we are using to break apart the cmdline from procfs produces an
empty slice from the last null character.