### PR TITLE
Pass __WALL to waitpid()

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -185,7 +185,7 @@ pub struct ThreadLock {
 impl ThreadLock {
     fn new(tid: nix::unistd::Pid) -> Result<ThreadLock, nix::Error> {
         ptrace::attach(tid)?;
-        wait::waitpid(tid, Some(wait::WaitPidFlag::WSTOPPED))?;
+        wait::waitpid(tid, Some(wait::WaitPidFlag::WSTOPPED | wait::WaitPidFlag::__WALL))?;
         debug!("attached to thread {}", tid);
         Ok(ThreadLock{tid})
     }


### PR DESCRIPTION
Linux kernels before v4.7 require __WALL to be passed to waitpid() when waiting on "clone" children.  (This requirement was removed in https://github.com/torvalds/linux/commit/bf959931ddb88c4e4366e96dd22e68fa0db9527c.)

This change allows py-spy to attach to a multithreaded process with pre-4.7 kernels instead of failing with ECHILD.