### PR TITLE
Update regex to `1.5.5`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ proc-maps = "0.2.0"
 read-process-memory = "0.1.4"
 goblin = "0.4.3"
 memmap = "0.7.0"
-regex = "1"
+regex = "1.5.5"
 
 [target.'cfg(target_os="macos")'.dependencies]
 mach_o_sys = "0.1.1"


### PR DESCRIPTION
Update regex to `1.5.5` as per [security advisory](https://blog.rust-lang.org/2022/03/08/cve-2022-24713.html)