### PR TITLE
Limit nix features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ mach = "0.3.2"
 libproc = "0.12"
 
 [target.'cfg(target_os="linux")'.dependencies]
-nix="0.24"
+nix = {version = "0.24", default-features = false, features = ["ptrace", "sched", "signal"]}
 object = "0.27"
 addr2line = "0.17"
 lazy_static = "1.4.0"


### PR DESCRIPTION
This slightly decreases clean build times, and removes memoffset as an indirect dependency.