### PR TITLE
Detect statically linked musl using the crt-static target feature, not target_vendor=alpine

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -11,11 +11,15 @@ fn main() {
 
     match env::var("CARGO_CFG_TARGET_OS").unwrap().as_ref() {
         "linux" => {
-            // statically link libunwind if compiling for musl, dynamically link otherwise
+            // statically link libunwind if statically linking musl (e.g. the
+            // `crt-static` target feature is present), dynamically link
+            // otherwise
             if env::var("CARGO_FEATURE_UNWIND").is_ok() {
                 println!("cargo:rustc-cfg=use_libunwind");
                 if env::var("CARGO_CFG_TARGET_ENV").unwrap() == "musl"
-                    && env::var("CARGO_CFG_TARGET_VENDOR").unwrap() != "alpine"
+                    && !env::var("CARGO_CFG_TARGET_FEATURE")
+                        .unwrap_or_default()
+                        .contains("crt-static")
                 {
                     println!("cargo:rustc-link-search=native=/usr/local/lib");
 


### PR DESCRIPTION
Someone reported a bug in the rust-lang zulip about your crate. I happened to notice that you're detecting statically linked musl the wrong way (or, a way that doesn't handle all cases), which is the cause of their bug. This probably fixes the issue for them, so long as they also provide some rustflags when compiling (specifically `RUSTFLAGS=-Ctarget-feature=-crt-static` to turn off static CRT).

That said, this is extremely a driveby, I haven't tested it beyond being confident that this doesn't break the existing use case, as the alpine target doesn't set crt-static.