### PR TITLE
Swap linux symbolication's unmaintained memmap dependency for memmap2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ log = "0.4"
 proc-maps = "0.3.2"
 read-process-memory = "0.1.6"
 goblin = "0.7.1"
-memmap = "0.7.0"
 regex = ">=1.8.3"
 
 [target.'cfg(target_os="macos")'.dependencies]
@@ -29,6 +28,7 @@ nix = {version = "0.26", default-features = false, features = ["ptrace", "sched"
 object = "0.32"
 addr2line = "0.21"
 lazy_static = "1.4.0"
+memmap2 = "0.9.4"
 
 [target.'cfg(windows)'.dependencies]
 winapi = {version = "0.3", features = ["winbase", "consoleapi", "wincon", "handleapi", "timeapi", "processenv" ]}

--- a/src/linux/symbolication.rs
+++ b/src/linux/symbolication.rs
@@ -4,8 +4,7 @@ use std::fs::File;
 use std::path::Path;
 
 use log::{debug, error, info, trace, warn};
-use memmap;
-use memmap::Mmap;
+use memmap2::Mmap;
 
 use crate::{Error, Pid, Process, StackFrame};
 use addr2line::ObjectContext;
@@ -224,7 +223,7 @@ impl SymbolData {
         info!("opening {} for symbols", filename);
 
         let file = File::open(filename)?;
-        let map = unsafe { memmap::Mmap::map(&file)? };
+        let map = unsafe { Mmap::map(&file)? };
         let file = match object::File::parse(&*map) {
             Ok(f) => f,
             Err(e) => {


### PR DESCRIPTION
Fixes: #84
Fixes: https://rustsec.org/advisories/RUSTSEC-2020-0077