### PR TITLE
Add missing winapi feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ addr2line = "0.21"
 lazy_static = "1.4.0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = {version = "0.3", features = ["winbase", "consoleapi", "wincon", "handleapi", "timeapi", "processenv" ]}
+winapi = {version = "0.3", features = ["winbase", "consoleapi", "wincon", "handleapi", "timeapi", "processenv", "errhandlingapi" ]}
 
 [dev-dependencies]
 env_logger = "0.10"


### PR DESCRIPTION
Currently `remoteprocess` (and in turn `py-spy` and other dependents) fail to compile on Windows due to the missing feature. It's used here: https://github.com/benfred/remoteprocess/blob/3e94f997345565e3dfe36e1dc206abb557c13e67/src/windows/symbolication.rs#L11

Fixes [py-spy/issues/668](https://github.com/benfred/py-spy/issues/668)