### PR TITLE
Windows aarch64 port.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ read-process-memory = "0.1.6"
 goblin = "0.7.1"
 memmap = "0.7.0"
 regex = ">=1.8.3"
+cfg-if = "1.0.0"
 
 [target.'cfg(target_os="macos")'.dependencies]
 mach_o_sys = "0.1.1"
@@ -31,7 +32,7 @@ addr2line = "0.21"
 lazy_static = "1.4.0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = {version = "0.3", features = ["winbase", "consoleapi", "wincon", "handleapi", "timeapi", "processenv" ]}
+winapi = {version = "0.3", features = ["winbase", "consoleapi", "wincon", "handleapi", "timeapi", "processenv", "errhandlingapi" ]}
 
 [dev-dependencies]
 env_logger = "0.10"

--- a/src/windows/unwinder.rs
+++ b/src/windows/unwinder.rs
@@ -44,9 +44,17 @@ impl Cursor {
                 addr.Offset = offset;
                 addr.Mode = AddrModeFlat;
             }
-            set_flat_addr(&mut frame.AddrStack, ctx.0.Rsp as u64);
-            set_flat_addr(&mut frame.AddrFrame, ctx.0.Rbp as u64);
-            set_flat_addr(&mut frame.AddrPC, ctx.0.Rip as u64);
+            cfg_if::cfg_if! {
+                if #[cfg(target_arch = "aarch64")] {
+                  set_flat_addr(&mut frame.AddrStack, ctx.0.Sp as u64);
+                  set_flat_addr(&mut frame.AddrFrame, ctx.0.u.s().Lr as u64);
+                  set_flat_addr(&mut frame.AddrPC, ctx.0.Pc as u64);
+                } else {
+                  set_flat_addr(&mut frame.AddrStack, ctx.0.Rsp as u64);
+                  set_flat_addr(&mut frame.AddrFrame, ctx.0.Rbp as u64);
+                  set_flat_addr(&mut frame.AddrPC, ctx.0.Rip as u64);
+                }
+            }
 
             Ok(Cursor {
                 ctx,


### PR DESCRIPTION
Currently building the library fails on windows/aarch64, becaues the unwinding functionality relies on x86 registers.

This commit ports the library to windows/aarch64 by utilizing the coresponding aarch64 registers.