### PR TITLE
Handle SIGTSTP in linux threadlock

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -240,11 +240,11 @@ impl ThreadLock {
                 Some(wait::WaitPidFlag::WSTOPPED | wait::WaitPidFlag::__WALL),
             )? {
                 // We only really expect to see a `PTRACE_EVENT_STOP`.
-                wait::WaitStatus::PtraceEvent(_, nix::sys::signal::Signal::SIGTRAP, event)
-                    if event == ptrace::Event::PTRACE_EVENT_STOP as i32 =>
-                {
-                    break
-                }
+                wait::WaitStatus::PtraceEvent(
+                    _,
+                    nix::sys::signal::Signal::SIGTRAP | nix::sys::signal::Signal::SIGTSTP,
+                    event,
+                ) if event == ptrace::Event::PTRACE_EVENT_STOP as i32 => break,
                 // However, experimentally, it appears we see an exit status when
                 // a process is dying.
                 wait::WaitStatus::Exited(_, _) => break,


### PR DESCRIPTION
If the a process was already stopped (for instance by hitting control-z), we used to be able to still treat it as locked - but with recent changes to use ptrace seize/interrupt, this no longer worked.

Fix by handling SIGTSTP.