### PR TITLE
upgrade docker ci images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,9 +48,15 @@ jobs:
     needs: [lint]
     strategy:
       matrix:
-        target: [i686-musl, x86_64-musl, armv7-musleabihf, aarch64-musl]
+        target:
+          [
+            i686-unknown-linux-musl,
+            armv7-unknown-linux-musleabihf,
+            aarch64-unknown-linux-musl,
+            x86_64-unknown-linux-musl,
+          ]
     container:
-      image: docker://benfred/rust-musl-cross:${{ matrix.target }}
+      image: ghcr.io/benfred/rust-musl-cross:${{ matrix.target }}
       env:
         RUSTUP_HOME: /root/.rustup
         CARGO_HOME: /root/.cargo
@@ -58,14 +64,14 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build (unwind)
       run: cargo build --verbose --features unwind --examples
-      if: matrix.target == 'x86_64-musl'  || matrix.target == 'armv7-musleabihf'
+      if: matrix.target == 'x86_64-unknown-linux-musl'  || matrix.target == 'armv7-unknown-linux-musleabihf'
     - name: Build (no-unwind)
       run: cargo build --verbose --examples
-      if: matrix.target == 'i686-musl' || matrix.target == 'aarch64-musl'
+      if: matrix.target == 'i686-unknown-linux-musl' || matrix.target == 'aarch64-unknown-linux-musl'
     # unittests don't compile here - with some duplicate symbol errors.
     # - name: Run tests
     #  run: cargo test --verbose --features unwind
-    #  if: matrix.target == 'x86_64-musl'
+    #  if: matrix.target == 'x86_64-unknown-linux-musl'
 
   build-freebsd:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Similar to https://github.com/benfred/py-spy/pull/702/, this upgrades GHA to use newer docker images for CI.