### PR TITLE
Mark the freebsd `test_process_and_thread_lock` as flaky

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ winapi = {version = "0.3", features = ["winbase", "consoleapi", "wincon", "handl
 [dev-dependencies]
 env_logger = "0.10"
 
+[target.'cfg(target_os="freebsd")'.dev-dependencies]
+mark-flaky-tests = "1"
+
 [features]
 default = []
 unwind = []

--- a/src/freebsd/mod.rs
+++ b/src/freebsd/mod.rs
@@ -145,12 +145,12 @@ impl ProcessMemory for Process {
 mod tests {
     use libc::pid_t;
     use log::warn;
+    use mark_flaky_tests::flaky;
 
-    use super::Error;
     use std::process::{Child, Command};
     use std::{thread, time};
 
-    use super::Process;
+    use super::{Error, Process};
 
     struct DroppableProcess {
         inner: Child,
@@ -300,7 +300,7 @@ mod tests {
     /// Since threads and their process use the same locking mechanics, it's
     /// crucial to ensure that double-locking doesn't occur. In case of
     /// double-lock program would panic, since ptrace(2) returns EBUSY.
-    #[test]
+    #[flaky]
     fn test_process_and_thread_lock() {
         trace_perl_program(PERL_PROGRAM)
             .and_then(|(process, _p)| {


### PR DESCRIPTION
We're seeing frequent CI failures around the freebsd test_process_and_thread_lock test. Re-running the tests usually causes this to pass.

Use the mark_flaky_tests to automatically retry this test until we can fix